### PR TITLE
Block-per-line revisions

### DIFF
--- a/parsers/rust/Cargo.lock
+++ b/parsers/rust/Cargo.lock
@@ -276,7 +276,7 @@ dependencies = [
 
 [[package]]
 name = "subtext"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "async-compat",

--- a/parsers/rust/subtext/Cargo.toml
+++ b/parsers/rust/subtext/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "subtext"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2021"
 
 [features]

--- a/parsers/rust/subtext/examples/example.subtext
+++ b/parsers/rust/subtext/examples/example.subtext
@@ -5,6 +5,7 @@ Some body text
 - List item one
 - List item two
 - List /with_link
+ - Not a list item
 
 > Block quote
 

--- a/parsers/rust/subtext/src/block.rs
+++ b/parsers/rust/subtext/src/block.rs
@@ -18,11 +18,11 @@ impl<E> Block<E>
 where
     E: From<Entity> + AsRef<Entity>,
 {
-    /// Get the text content of a block. For paragraphs, this is the content
+    /// Get the content entities for a block. For paragraphs, this is content
     /// that appears after leading whitespace; for headings, lists and block
     /// quotes, this is the content that appears after a sigil and subsequent
     /// leading whitespace; for blanks, this is empty.
-    pub fn to_text_content(&self) -> String {
+    pub fn to_content_entities(&self) -> Vec<&E> {
         match self {
             Block::Header(entities) | Block::List(entities) | Block::Quote(entities) => entities
                 .iter()
@@ -30,7 +30,6 @@ where
                     Entity::Sigil(_) | Entity::EmptySpace(_) => true,
                     _ => false,
                 })
-                .map(|entity| entity.as_ref().to_string())
                 .collect(),
             Block::Paragraph(entities) => entities
                 .iter()
@@ -38,10 +37,18 @@ where
                     Entity::EmptySpace(_) => true,
                     _ => false,
                 })
-                .map(|entity| entity.as_ref().to_string())
                 .collect(),
-            Block::Blank(_) => String::new(),
+            Block::Blank(_) => Vec::new(),
         }
+    }
+
+    /// Get the text content of a block, which is the concatenated string
+    /// representation of all its content entities.
+    pub fn to_text_content(&self) -> String {
+        self.to_content_entities()
+            .iter()
+            .map(|entity| entity.as_ref().to_string())
+            .collect()
     }
 
     pub fn to_bytes(&self) -> Vec<u8> {

--- a/parsers/rust/subtext/src/block.rs
+++ b/parsers/rust/subtext/src/block.rs
@@ -1,5 +1,6 @@
+use crate::str::SharedString;
 use crate::{primitive, primitive::Entity, util::cut};
-use tendril::{StrTendril, SubtendrilError};
+use tendril::SubtendrilError;
 
 #[derive(Debug, Clone)]
 pub enum Block<E>
@@ -62,14 +63,14 @@ where
 }
 
 pub fn parse_empty_space<E: From<Entity> + AsRef<Entity>>(
-    input: StrTendril,
+    input: SharedString,
 ) -> Result<(Block<E>, usize), SubtendrilError> {
     let (primitive, steps) = primitive::parse_empty_space(input)?;
     Ok((Block::Seperator(primitive.into()), steps))
 }
 
 pub fn parse_paragraph<E: From<Entity> + AsRef<Entity>>(
-    input: StrTendril,
+    input: SharedString,
 ) -> Result<(Block<E>, usize), SubtendrilError> {
     let (primitives, steps) = primitive::parse_text::<E>(input)?;
 
@@ -88,7 +89,7 @@ pub fn parse_paragraph<E: From<Entity> + AsRef<Entity>>(
 }
 
 pub fn parse_link<E: From<Entity> + AsRef<Entity>>(
-    input: StrTendril,
+    input: SharedString,
 ) -> Result<(Block<E>, usize), SubtendrilError> {
     let (primitive, steps) = match input.chars().nth(0) {
         Some('/') => primitive::parse_slash_link(input)?,
@@ -99,7 +100,7 @@ pub fn parse_link<E: From<Entity> + AsRef<Entity>>(
 }
 
 fn parse_with_sigil<E: From<Entity> + AsRef<Entity>>(
-    input: StrTendril,
+    input: SharedString,
     sigil: char,
 ) -> Result<(Vec<E>, usize), SubtendrilError> {
     let mut iter = input.char_indices().peekable();
@@ -143,21 +144,21 @@ fn parse_with_sigil<E: From<Entity> + AsRef<Entity>>(
 }
 
 pub fn parse_header<E: From<Entity> + AsRef<Entity>>(
-    input: StrTendril,
+    input: SharedString,
 ) -> Result<(Block<E>, usize), SubtendrilError> {
     let (primitives, end) = parse_with_sigil(input, '#')?;
     Ok((Block::Header(primitives), end))
 }
 
 pub fn parse_quote<E: From<Entity> + AsRef<Entity>>(
-    input: StrTendril,
+    input: SharedString,
 ) -> Result<(Block<E>, usize), SubtendrilError> {
     let (primitives, end) = parse_with_sigil(input, '>')?;
     Ok((Block::Quote(primitives), end))
 }
 
 pub fn parse_list<E: From<Entity> + AsRef<Entity>>(
-    input: StrTendril,
+    input: SharedString,
 ) -> Result<(Block<E>, usize), SubtendrilError> {
     let mut iter = input.char_indices().peekable();
     let mut items = Vec::<Vec<E>>::new();

--- a/parsers/rust/subtext/src/lib.rs
+++ b/parsers/rust/subtext/src/lib.rs
@@ -6,6 +6,7 @@ mod parse;
 mod predicate;
 pub mod primitive;
 mod sequence;
+pub mod str;
 pub mod util;
 
 pub use parse::parse;

--- a/parsers/rust/subtext/src/lib.rs
+++ b/parsers/rust/subtext/src/lib.rs
@@ -6,8 +6,10 @@ mod parse;
 mod predicate;
 pub mod primitive;
 mod sequence;
+mod slashlink;
 pub mod str;
 pub mod util;
+pub use slashlink::*;
 
 pub use parse::parse;
 

--- a/parsers/rust/subtext/src/parse.rs
+++ b/parsers/rust/subtext/src/parse.rs
@@ -6,7 +6,8 @@ use crate::{
     util::cut,
 };
 use anyhow::{anyhow, Result};
-use tendril::StrTendril;
+// use tendril::SharedString;
+use crate::str::SharedString;
 
 /// Parse a raw buffer as a chunk of subtext. The iterator yields the parsed
 /// subtext one block at a time.
@@ -15,7 +16,7 @@ where
     E: From<Entity> + AsRef<Entity>,
     B: From<Block<E>>,
 {
-    let input = StrTendril::try_from_byte_slice(input)
+    let input = SharedString::try_from_byte_slice(input)
         .map_err(|_| anyhow!("Could not interpret bytes as UTF-8"))?;
     Ok(SubtextIterator::new(input))
 }
@@ -25,7 +26,7 @@ where
     E: From<Entity> + AsRef<Entity>,
     B: From<Block<E>>,
 {
-    input: StrTendril,
+    input: SharedString,
     output_type: PhantomData<(B, E)>,
 }
 
@@ -34,7 +35,7 @@ where
     E: From<Entity> + AsRef<Entity>,
     B: From<Block<E>>,
 {
-    pub fn new(input: StrTendril) -> Self {
+    pub fn new(input: SharedString) -> Self {
         SubtextIterator {
             input,
             output_type: PhantomData {},

--- a/parsers/rust/subtext/src/parse.rs
+++ b/parsers/rust/subtext/src/parse.rs
@@ -1,7 +1,7 @@
 use std::marker::PhantomData;
 
 use crate::{
-    block::{parse_empty_space, parse_header, parse_list, parse_paragraph, parse_quote, Block},
+    block::{parse_blank, parse_header, parse_list, parse_paragraph, parse_quote, Block},
     primitive::Entity,
     util::cut,
 };
@@ -53,7 +53,7 @@ where
     fn next(&mut self) -> Option<Self::Item> {
         if let Some(token) = self.input.chars().next() {
             let parse_block = match token {
-                '\r' | '\n' | ' ' | '\t' => parse_empty_space,
+                '\r' | '\n' | ' ' | '\t' => parse_blank,
                 '#' => parse_header,
                 '-' => parse_list,
                 '>' => parse_quote,

--- a/parsers/rust/subtext/src/parse.rs
+++ b/parsers/rust/subtext/src/parse.rs
@@ -1,9 +1,8 @@
 use std::marker::PhantomData;
 
+use crate::str::SharedString;
 use crate::{block::Block, primitive::Entity, util::cut};
 use anyhow::{anyhow, Result};
-// use tendril::SharedString;
-use crate::str::SharedString;
 
 /// Parse a raw buffer as a chunk of subtext. The iterator yields the parsed
 /// subtext one block at a time.

--- a/parsers/rust/subtext/src/parse.rs
+++ b/parsers/rust/subtext/src/parse.rs
@@ -1,10 +1,6 @@
 use std::marker::PhantomData;
 
-use crate::{
-    block::{parse_blank, parse_header, parse_list, parse_paragraph, parse_quote, Block},
-    primitive::Entity,
-    util::cut,
-};
+use crate::{block::Block, primitive::Entity, util::cut};
 use anyhow::{anyhow, Result};
 // use tendril::SharedString;
 use crate::str::SharedString;
@@ -51,16 +47,8 @@ where
     type Item = B;
 
     fn next(&mut self) -> Option<Self::Item> {
-        if let Some(token) = self.input.chars().next() {
-            let parse_block = match token {
-                '\r' | '\n' | ' ' | '\t' => parse_blank,
-                '#' => parse_header,
-                '-' => parse_list,
-                '>' => parse_quote,
-                _ => parse_paragraph,
-            };
-
-            match parse_block(self.input.clone()) {
+        if self.input.len() > 0 {
+            match crate::block::parse(self.input.clone()) {
                 Ok((block, steps)) => {
                     let steps = usize::min(steps, self.input.len());
                     self.input = match cut(&self.input, steps) {

--- a/parsers/rust/subtext/src/primitive.rs
+++ b/parsers/rust/subtext/src/primitive.rs
@@ -18,6 +18,9 @@ pub enum Entity {
     WikiLink(SharedString),
 }
 
+// TODO: Investigate the validity of this
+unsafe impl Sync for Entity {}
+
 impl AsRef<Entity> for Entity {
     fn as_ref(&self) -> &Entity {
         self

--- a/parsers/rust/subtext/src/primitive.rs
+++ b/parsers/rust/subtext/src/primitive.rs
@@ -1,4 +1,5 @@
-use tendril::{StrTendril, SubtendrilError};
+use crate::str::SharedString;
+use tendril::SubtendrilError;
 
 use crate::{
     predicate::{
@@ -9,12 +10,12 @@ use crate::{
 
 #[derive(Debug, Clone)]
 pub enum Entity {
-    Sigil(StrTendril),
-    TextSpan(StrTendril),
-    EmptySpace(StrTendril),
-    SlashLink(StrTendril),
-    HyperLink(StrTendril),
-    WikiLink(StrTendril),
+    Sigil(SharedString),
+    TextSpan(SharedString),
+    EmptySpace(SharedString),
+    SlashLink(SharedString),
+    HyperLink(SharedString),
+    WikiLink(SharedString),
 }
 
 impl AsRef<Entity> for Entity {
@@ -47,7 +48,7 @@ impl Entity {
     }
 }
 
-pub fn parse_empty_space(input: StrTendril) -> Result<(Entity, usize), SubtendrilError> {
+pub fn parse_empty_space(input: SharedString) -> Result<(Entity, usize), SubtendrilError> {
     let mut iter = input.char_indices().peekable();
     let mut end = 0usize;
 
@@ -68,9 +69,9 @@ pub fn parse_empty_space(input: StrTendril) -> Result<(Entity, usize), Subtendri
 }
 
 pub fn parse_until<P>(
-    input: StrTendril,
+    input: SharedString,
     mut predicate: P,
-) -> Result<(StrTendril, usize), SubtendrilError>
+) -> Result<(SharedString, usize), SubtendrilError>
 where
     P: FnMut(&char) -> Option<usize>,
 {
@@ -92,28 +93,28 @@ where
     return Ok((input, end + 1));
 }
 
-pub fn parse_slash_link(input: StrTendril) -> Result<(Entity, usize), SubtendrilError> {
+pub fn parse_slash_link(input: SharedString) -> Result<(Entity, usize), SubtendrilError> {
     match parse_until(input, white_space_predicate()) {
         Ok((value, steps)) => Ok((Entity::SlashLink(value), steps)),
         Err(error) => Err(error),
     }
 }
 
-pub fn parse_hyper_link(input: StrTendril) -> Result<(Entity, usize), SubtendrilError> {
+pub fn parse_hyper_link(input: SharedString) -> Result<(Entity, usize), SubtendrilError> {
     match parse_until(input, white_space_predicate()) {
         Ok((value, steps)) => Ok((Entity::HyperLink(value), steps)),
         Err(error) => Err(error),
     }
 }
 
-pub fn parse_wiki_link(input: StrTendril) -> Result<(Entity, usize), SubtendrilError> {
+pub fn parse_wiki_link(input: SharedString) -> Result<(Entity, usize), SubtendrilError> {
     match parse_until(input, wiki_link_delimiter_predicate()) {
         Ok((value, steps)) => Ok((Entity::WikiLink(value), steps)),
         Err(error) => Err(error),
     }
 }
 
-pub fn parse_text<E>(input: StrTendril) -> Result<(Vec<E>, usize), SubtendrilError>
+pub fn parse_text<E>(input: SharedString) -> Result<(Vec<E>, usize), SubtendrilError>
 where
     E: From<Entity> + AsRef<Entity>,
 {

--- a/parsers/rust/subtext/src/slashlink.rs
+++ b/parsers/rust/subtext/src/slashlink.rs
@@ -1,0 +1,135 @@
+use anyhow::anyhow;
+use std::{fmt::Display, str::FromStr};
+
+/// The various forms that the "peer" part of a slashlink may take
+#[derive(Debug, PartialEq)]
+pub enum Peer {
+    Name(String),
+    Did(String),
+    None,
+}
+
+/// A slashlink is form of reference to content in a Sphere. It consists of a
+/// peer part and a slug part. A slashlink with just the slug looks like:
+/// `/foo`. A slashlink with just the peer looks like: `@cdata`. With both
+/// parts, the link would look like: `@cdata/foo`.
+///
+/// This struct makes it easier to parse a slashlink from a string.
+#[derive(Debug, PartialEq)]
+pub struct Slashlink {
+    pub peer: Peer,
+    pub slug: Option<String>,
+}
+
+impl FromStr for Slashlink {
+    type Err = anyhow::Error;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let mut parsing_peer = false;
+        let mut parsing_link = false;
+
+        let mut raw_peer = String::new();
+        let mut slug = None;
+
+        for (index, character) in s.char_indices() {
+            match character {
+                '@' if index == 0 => {
+                    parsing_peer = true;
+                }
+                '/' if index == 0 || parsing_peer => {
+                    parsing_peer = false;
+                    parsing_link = true;
+                }
+                _ if parsing_peer => raw_peer.push(character),
+                _ if parsing_link => {
+                    slug = Some(s[index..].to_string());
+                    break;
+                }
+                _ => {
+                    break;
+                }
+            }
+        }
+
+        let peer = if raw_peer.len() > 0 {
+            match raw_peer[0..4].to_lowercase().as_str() {
+                "did:" => Peer::Did(raw_peer),
+                _ => Peer::Name(raw_peer),
+            }
+        } else {
+            Peer::None
+        };
+
+        if peer == Peer::None && slug == None {
+            Err(anyhow!("Could not parse {} as SlashLink", s))
+        } else {
+            Ok(Slashlink { peer, slug })
+        }
+    }
+}
+
+impl Display for Slashlink {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match &self.peer {
+            Peer::Name(name) => write!(f, "@{}", name),
+            Peer::Did(did) => write!(f, "@{}", did),
+            Peer::None => Ok(()),
+        }?;
+
+        match &self.slug {
+            Some(slug) => write!(f, "/{}", slug),
+            None => Ok(()),
+        }?;
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::str::FromStr;
+
+    use crate::slashlink::{Peer, Slashlink};
+
+    #[test]
+    fn it_can_parse_a_basic_slashlink() {
+        let slashlink = Slashlink::from_str("/foo-bar").unwrap();
+
+        assert_eq!(slashlink.peer, Peer::None);
+        assert_eq!(slashlink.slug, Some("foo-bar".into()));
+    }
+
+    #[test]
+    fn it_can_parse_a_basic_slashlink_with_a_peer_name() {
+        let slashlink = Slashlink::from_str("@cdata/foo-bar").unwrap();
+
+        assert_eq!(slashlink.peer, Peer::Name("cdata".into()));
+        assert_eq!(slashlink.slug, Some("foo-bar".into()));
+    }
+
+    #[test]
+    #[ignore = "TODO(subconsciousnetwork/subtext#36)"]
+    fn it_can_parse_a_slashlink_that_is_a_cid() {}
+
+    #[test]
+    fn it_can_parse_a_slashlink_with_a_peer_did() {
+        let slashlink = Slashlink::from_str("@did:test:alice/foo-bar").unwrap();
+        assert_eq!(slashlink.peer, Peer::Did("did:test:alice".into()));
+        assert_eq!(slashlink.slug, Some("foo-bar".into()));
+    }
+
+    #[test]
+    fn it_can_parse_a_slashlink_with_only_a_peer() {
+        let slashlink = Slashlink::from_str("@cdata").unwrap();
+        assert_eq!(slashlink.peer, Peer::Name("cdata".into()));
+    }
+
+    #[test]
+    fn it_will_not_parse_a_non_slashlink() {
+        let non_slashlinks = vec!["cdata", "@", "/", "@/", "foo/bar"];
+        for test_case in non_slashlinks {
+            println!("Checking {}", test_case);
+            assert!(Slashlink::from_str(test_case).is_err())
+        }
+    }
+}

--- a/parsers/rust/subtext/src/str.rs
+++ b/parsers/rust/subtext/src/str.rs
@@ -1,0 +1,3 @@
+use tendril::{fmt::UTF8, Atomic, Tendril};
+
+pub type SharedString = Tendril<UTF8, Atomic>;

--- a/parsers/rust/subtext/src/test/blank.rs
+++ b/parsers/rust/subtext/src/test/blank.rs
@@ -1,0 +1,77 @@
+use crate::{block::Block, parse, primitive::Entity};
+
+#[test]
+fn it_dissolves_a_terminating_newline() {
+    let input = r#"Hello,
+World!"#;
+
+    let blocks: Vec<Block<Entity>> = parse(input.as_ref()).unwrap().collect();
+
+    match blocks.as_slice() {
+        [Block::Paragraph(hello), Block::Paragraph(world)] => {
+            assert_eq!(hello.first().unwrap().to_string(), "Hello,");
+            assert_eq!(world.first().unwrap().to_string(), "World!");
+        }
+        _ => panic!("Unexpected block(s) or primitive(s): {:#?}", blocks),
+    }
+}
+
+#[test]
+fn it_captures_extra_empty_space_in_a_blank() {
+    let input = r#"Hello,
+  
+World!"#;
+
+    let blocks: Vec<Block<Entity>> = parse(input.as_ref()).unwrap().collect();
+
+    match blocks.as_slice() {
+        [Block::Paragraph(hello), Block::Blank(empty), Block::Paragraph(world)] => {
+            assert_eq!(hello.first().unwrap().to_string(), "Hello,");
+            assert_eq!(empty.to_string(), "  ");
+            assert_eq!(world.first().unwrap().to_string(), "World!");
+        }
+        _ => panic!("Unexpected block(s) or primitive(s): {:#?}", blocks),
+    }
+}
+
+#[test]
+fn it_recognizes_zero_length_lines_as_blanks() {
+    let input = r#"Hello,
+  
+
+     
+World!"#;
+
+    let blocks: Vec<Block<Entity>> = parse(input.as_ref()).unwrap().collect();
+
+    match blocks.as_slice() {
+        [Block::Paragraph(hello), Block::Blank(empty_one), Block::Blank(empty_two), Block::Blank(empty_three), Block::Paragraph(world)] =>
+        {
+            assert_eq!(hello.first().unwrap().to_string(), "Hello,");
+            assert_eq!(empty_one.to_string(), "  ");
+            assert_eq!(empty_two.to_string(), "");
+            assert_eq!(empty_three.to_string(), "     ");
+            assert_eq!(world.first().unwrap().to_string(), "World!");
+        }
+        _ => panic!("Unexpected block(s) or primitive(s): {:#?}", blocks),
+    }
+}
+
+#[test]
+fn it_does_not_absorb_leading_whitespace_into_a_preceding_blank() {
+    let input = r#"Hello,
+
+ - World!"#;
+
+    let blocks: Vec<Block<Entity>> = parse(input.as_ref()).unwrap().collect();
+
+    match blocks.as_slice() {
+        [Block::Paragraph(hello), Block::Blank(empty), world @ Block::Paragraph(world_entities)] => {
+            assert_eq!(hello.first().unwrap().to_string(), "Hello,");
+            assert_eq!(empty.to_string(), "");
+            assert_eq!(world_entities.first().unwrap().to_string(), " ");
+            assert_eq!(world.to_string(), " - World!");
+        }
+        _ => panic!("Unexpected block(s) or primitive(s): {:#?}", blocks),
+    }
+}

--- a/parsers/rust/subtext/src/test/block.rs
+++ b/parsers/rust/subtext/src/test/block.rs
@@ -1,16 +1,4 @@
-use crate::{block::Block, parse, primitive::Entity};
-
-fn assert_round_trip(input: &str) {
-    let block: Block<Entity> = parse(input.as_bytes()).unwrap().nth(0).unwrap();
-
-    let actual_bytes = block.to_bytes();
-    let expected_bytes = Vec::from(input.as_bytes());
-
-    let actual_string = String::from_utf8(actual_bytes).unwrap();
-    let expected_string = String::from_utf8(expected_bytes).unwrap();
-
-    assert_eq!(expected_string, actual_string);
-}
+use crate::util::assert_round_trip;
 
 #[test]
 fn it_converts_a_list_block_to_bytes() {

--- a/parsers/rust/subtext/src/test/mod.rs
+++ b/parsers/rust/subtext/src/test/mod.rs
@@ -1,4 +1,6 @@
+mod blank;
 mod block;
 mod parse;
 mod primitive;
 mod sequence;
+mod text_content;

--- a/parsers/rust/subtext/src/test/parse.rs
+++ b/parsers/rust/subtext/src/test/parse.rs
@@ -12,11 +12,14 @@ fn empty_space() {
 
     let blocks: Vec<Block<Entity>> = parse(input.as_bytes()).unwrap().collect();
 
-    assert_eq!(blocks.len(), 1);
+    assert_eq!(blocks.len(), 3);
 
-    match blocks.first() {
-        Some(block::Block::Blank(primitive)) => {
-            assert_eq!(primitive.to_string(), input);
+    match &blocks.as_slice()[..] {
+        [block::Block::Blank(first), block::Block::Blank(second), block::Block::Blank(third)] => {
+            // assert_eq!(primitive.to_string(), input);
+            assert_eq!(first.to_string(), "  ");
+            assert_eq!(second.to_string(), "");
+            assert_eq!(third.to_string(), "          ");
         }
         _ => panic!("Incorrect block type!"),
     }
@@ -31,8 +34,9 @@ fn basic_slash_links() {
     assert_eq!(blocks.len(), 1);
 
     match blocks.first() {
-        Some(block::Block::Link(primitive::Entity::SlashLink(value))) => {
-            assert_eq!(value.to_string(), "/foo/bar");
+        Some(block::Block::Paragraph(parts)) => {
+            assert_eq!(parts.len(), 1);
+            assert_eq!(parts.first().unwrap().to_string(), input);
         }
         _ => panic!("Incorrect block or primitive type!"),
     }
@@ -83,8 +87,9 @@ fn basic_hyper_links() {
     assert_eq!(blocks.len(), 1);
 
     match blocks.first() {
-        Some(block::Block::Link(primitive)) => {
-            assert_eq!(primitive.to_string(), input);
+        Some(block::Block::Paragraph(parts)) => {
+            assert_eq!(parts.len(), 1);
+            assert_eq!(parts.first().unwrap().to_string(), input);
         }
         _ => panic!("Incorrect block type!"),
     }
@@ -93,12 +98,11 @@ fn basic_hyper_links() {
 #[test]
 fn basic_lists() {
     let input = r#"- One
- - Two
- - Three"#;
+- Two
+- Three"#;
 
     let blocks: Vec<Block<Entity>> = parse(input.as_bytes()).unwrap().collect();
 
-    println!("{:#?}", blocks);
     assert_eq!(blocks.len(), 3);
 
     match blocks.as_slice() {
@@ -228,8 +232,8 @@ mod lists {
     #[test]
     fn one_item_is_a_sublink() {
         let input = r#"- One
- - /two
- - Three"#;
+- /two
+- Three"#;
 
         let blocks: Vec<Block<Entity>> = parse(input.as_bytes()).unwrap().collect();
 
@@ -475,5 +479,5 @@ http://www.google.com
 
     let blocks: Vec<Block<Entity>> = parse(subtext.as_bytes()).unwrap().collect();
 
-    assert_eq!(blocks.len(), 7);
+    assert_eq!(blocks.len(), 10);
 }

--- a/parsers/rust/subtext/src/test/parse.rs
+++ b/parsers/rust/subtext/src/test/parse.rs
@@ -15,7 +15,7 @@ fn empty_space() {
     assert_eq!(blocks.len(), 1);
 
     match blocks.first() {
-        Some(block::Block::Seperator(primitive)) => {
+        Some(block::Block::Blank(primitive)) => {
             assert_eq!(primitive.to_string(), input);
         }
         _ => panic!("Incorrect block type!"),
@@ -98,31 +98,21 @@ fn basic_lists() {
 
     let blocks: Vec<Block<Entity>> = parse(input.as_bytes()).unwrap().collect();
 
-    assert_eq!(blocks.len(), 1);
+    println!("{:#?}", blocks);
+    assert_eq!(blocks.len(), 3);
 
-    match blocks.first() {
-        Some(block::Block::List(items)) => {
-            assert_eq!(items.len(), 3);
-
-            match items.as_slice() {
-                [one, two, three] => {
-                    assert_eq!(one.len(), 3);
-                    assert_eq!(two.len(), 3);
-                    assert_eq!(three.len(), 3);
-
-                    match (one.get(2), two.get(2), three.get(2)) {
-                        (Some(one), Some(two), Some(three)) => {
-                            assert_eq!(one.to_string(), "One");
-                            assert_eq!(two.to_string(), "Two");
-                            assert_eq!(three.to_string(), "Three");
-                        }
-                        _ => panic!("Unexpected list items!"),
-                    }
+    match blocks.as_slice() {
+        [Block::List(one), Block::List(two), Block::List(three)] => {
+            match (one.get(2), two.get(2), three.get(2)) {
+                (Some(one), Some(two), Some(three)) => {
+                    assert_eq!(one.to_string(), "One");
+                    assert_eq!(two.to_string(), "Two");
+                    assert_eq!(three.to_string(), "Three");
                 }
-                _ => panic!("Wrong list items!"),
+                _ => panic!("Unexpected list items!"),
             }
         }
-        _ => panic!("Incorrect block type!"),
+        _ => panic!("Incorrect set of blocks!"),
     }
 }
 
@@ -243,31 +233,20 @@ mod lists {
 
         let blocks: Vec<Block<Entity>> = parse(input.as_bytes()).unwrap().collect();
 
-        assert_eq!(blocks.len(), 1);
+        assert_eq!(blocks.len(), 3);
 
-        match blocks.first() {
-            Some(Block::List(items)) => {
-                assert_eq!(items.len(), 3);
-
-                match items.as_slice() {
-                    [one, two, three] => {
-                        assert_eq!(one.len(), 3);
-                        assert_eq!(two.len(), 3);
-                        assert_eq!(three.len(), 3);
-
-                        match (one.get(2), two.get(2), three.get(2)) {
-                            (Some(one), Some(two), Some(three)) => {
-                                assert_eq!(one.to_string(), "One");
-                                assert_eq!(two.to_string(), "/two");
-                                assert_eq!(three.to_string(), "Three");
-                            }
-                            _ => panic!("Unexpected list items!"),
-                        }
+        match blocks.as_slice() {
+            [Block::List(one), Block::List(two), Block::List(three)] => {
+                match (one.get(2), two.get(2), three.get(2)) {
+                    (Some(one), Some(two), Some(three)) => {
+                        assert_eq!(one.to_string(), "One");
+                        assert_eq!(two.to_string(), "/two");
+                        assert_eq!(three.to_string(), "Three");
                     }
-                    _ => panic!("Wrong list items!"),
+                    _ => panic!("Unexpected list items!"),
                 }
             }
-            _ => panic!("Incorrect block type!"),
+            _ => panic!("Incorrect set of blocks!"),
         }
     }
 }
@@ -486,6 +465,7 @@ fn it_parses_complex_multiline_subtext() {
     let subtext = r#"# Html
 
 It is a /markup language.
+Based around the concept of [[Blocks]].
 
 http://www.google.com
 

--- a/parsers/rust/subtext/src/test/primitive.rs
+++ b/parsers/rust/subtext/src/test/primitive.rs
@@ -1,5 +1,3 @@
-// use tendril::SharedString;
-
 use crate::{
     primitive::{parse_slash_link, parse_text, parse_wiki_link, Entity},
     str::SharedString,

--- a/parsers/rust/subtext/src/test/primitive.rs
+++ b/parsers/rust/subtext/src/test/primitive.rs
@@ -1,10 +1,13 @@
-use tendril::StrTendril;
+// use tendril::SharedString;
 
-use crate::primitive::{parse_slash_link, parse_text, parse_wiki_link, Entity};
+use crate::{
+    primitive::{parse_slash_link, parse_text, parse_wiki_link, Entity},
+    str::SharedString,
+};
 
 #[test]
 fn it_parses_a_slash_link_blap() {
-    let input = StrTendril::try_from_byte_slice(b"/foo").unwrap();
+    let input = SharedString::try_from_byte_slice(b"/foo").unwrap();
     let (entity, steps) = parse_slash_link(input).unwrap();
 
     assert_eq!(steps, 4);
@@ -13,7 +16,7 @@ fn it_parses_a_slash_link_blap() {
 
 #[test]
 fn it_parses_a_wiki_link() {
-    let input = StrTendril::try_from_byte_slice(b"[[foo bar baz]]").unwrap();
+    let input = SharedString::try_from_byte_slice(b"[[foo bar baz]]").unwrap();
     let (entity, steps) = parse_wiki_link(input).unwrap();
 
     assert_eq!(steps, 15);
@@ -22,7 +25,7 @@ fn it_parses_a_wiki_link() {
 
 #[test]
 fn it_parses_a_text_span() {
-    let input = StrTendril::try_from_byte_slice(b"foo bar baz").unwrap();
+    let input = SharedString::try_from_byte_slice(b"foo bar baz").unwrap();
     let (entities, steps) = parse_text::<Entity>(input).unwrap();
 
     assert_eq!(steps, 11);
@@ -32,7 +35,7 @@ fn it_parses_a_text_span() {
 
 #[test]
 fn it_parses_a_text_span_delimited_by_a_newline() {
-    let input = StrTendril::try_from_byte_slice(b"foo bar baz\n").unwrap();
+    let input = SharedString::try_from_byte_slice(b"foo bar baz\n").unwrap();
     let (entities, steps) = parse_text::<Entity>(input).unwrap();
 
     assert_eq!(steps, 11);
@@ -42,7 +45,7 @@ fn it_parses_a_text_span_delimited_by_a_newline() {
 
 #[test]
 fn it_parses_a_slash_link_in_a_text_span() {
-    let input = StrTendril::try_from_byte_slice(b"foo /bar baz").unwrap();
+    let input = SharedString::try_from_byte_slice(b"foo /bar baz").unwrap();
     let (entities, steps) = parse_text::<Entity>(input).unwrap();
 
     assert_eq!(steps, 12);
@@ -54,7 +57,7 @@ fn it_parses_a_slash_link_in_a_text_span() {
 
 #[test]
 fn it_parses_a_wiki_link_in_a_text_span() {
-    let input = StrTendril::try_from_byte_slice(b"foo [[bar]] baz").unwrap();
+    let input = SharedString::try_from_byte_slice(b"foo [[bar]] baz").unwrap();
     let (entities, steps) = parse_text::<Entity>(input).unwrap();
 
     assert_eq!(steps, 15);
@@ -66,7 +69,7 @@ fn it_parses_a_wiki_link_in_a_text_span() {
 
 #[test]
 fn it_parses_a_slash_link_following_a_text_span() {
-    let input = StrTendril::try_from_byte_slice(b"foo bar /baz").unwrap();
+    let input = SharedString::try_from_byte_slice(b"foo bar /baz").unwrap();
     let (entities, steps) = parse_text::<Entity>(input).unwrap();
 
     assert_eq!(steps, 12);

--- a/parsers/rust/subtext/src/test/text_content.rs
+++ b/parsers/rust/subtext/src/test/text_content.rs
@@ -1,0 +1,46 @@
+use crate::{block::Block, parse, primitive::Entity};
+
+#[test]
+fn it_skips_leading_whitespace_in_paragraphs() {
+    let input = "  Hello, world!";
+    let blocks: Vec<Block<Entity>> = parse(input.as_ref()).unwrap().collect();
+    let text_content = blocks.first().unwrap().to_text_content();
+
+    assert_eq!(text_content, "Hello, world!");
+}
+
+#[test]
+fn it_skips_the_sigil_and_leading_whitespace_for_headers() {
+    let input = "# Hello, world!";
+    let blocks: Vec<Block<Entity>> = parse(input.as_ref()).unwrap().collect();
+    let text_content = blocks.first().unwrap().to_text_content();
+
+    assert_eq!(text_content, "Hello, world!");
+}
+
+#[test]
+fn it_skips_the_sigil_and_leading_whitespace_for_lists() {
+    let input = "- Hello, world!";
+    let blocks: Vec<Block<Entity>> = parse(input.as_ref()).unwrap().collect();
+    let text_content = blocks.first().unwrap().to_text_content();
+
+    assert_eq!(text_content, "Hello, world!");
+}
+
+#[test]
+fn it_skips_the_sigil_and_leading_whitespace_for_quotes() {
+    let input = "> Hello, world!";
+    let blocks: Vec<Block<Entity>> = parse(input.as_ref()).unwrap().collect();
+    let text_content = blocks.first().unwrap().to_text_content();
+
+    assert_eq!(text_content, "Hello, world!");
+}
+
+#[test]
+fn it_yields_an_empty_string_for_blanks() {
+    let input = "   ";
+    let blocks: Vec<Block<Entity>> = parse(input.as_ref()).unwrap().collect();
+    let text_content = blocks.first().unwrap().to_text_content();
+
+    assert_eq!(text_content, "");
+}

--- a/parsers/rust/subtext/src/util.rs
+++ b/parsers/rust/subtext/src/util.rs
@@ -2,9 +2,10 @@ use anyhow::Result;
 use tendril::{SubtendrilError, Tendril};
 
 /// Cut a tendril at the given index. returning the rhs of the cut
-pub fn cut<T>(tendril: &Tendril<T>, at: usize) -> Result<Tendril<T>, SubtendrilError>
+pub fn cut<T, A>(tendril: &Tendril<T, A>, at: usize) -> Result<Tendril<T, A>, SubtendrilError>
 where
     T: tendril::Format,
+    A: tendril::Atomicity,
 {
     tendril.try_subtendril(at as u32, tendril.len32() - at as u32)
 }

--- a/parsers/rust/subtext/src/util.rs
+++ b/parsers/rust/subtext/src/util.rs
@@ -1,7 +1,7 @@
 use anyhow::Result;
 use tendril::{SubtendrilError, Tendril};
 
-/// Cut a tendril at the given index. returning the rhs of the cut
+/// Cut a tendril at the given index, returning the RHS of the cut
 pub fn cut<T, A>(tendril: &Tendril<T, A>, at: usize) -> Result<Tendril<T, A>, SubtendrilError>
 where
     T: tendril::Format,
@@ -10,6 +10,8 @@ where
     tendril.try_subtendril(at as u32, tendril.len32() - at as u32)
 }
 
+/// Slug-ify an arbitrary input string to make it compatible with
+/// Subconscious' notion of slashlink slugs
 pub fn to_slug(input: &str) -> Result<String> {
     let mut slug = input
         .trim()
@@ -48,15 +50,12 @@ pub fn to_slug(input: &str) -> Result<String> {
 pub fn assert_round_trip(input: &str) {
     let blocks: Vec<crate::block::Block<crate::primitive::Entity>> =
         crate::parse(input.as_bytes()).unwrap().collect();
-    let actual_bytes: Vec<u8> = blocks.iter().fold(Vec::new(), |mut bytes, block| {
-        bytes.append(&mut block.to_bytes());
-        bytes
-    });
 
-    let expected_bytes = Vec::from(input.as_bytes());
+    let actual_string = blocks
+        .iter()
+        .map(|block| block.to_string())
+        .collect::<Vec<String>>()
+        .join("\n");
 
-    let actual_string = String::from_utf8(actual_bytes).unwrap();
-    let expected_string = String::from_utf8(expected_bytes).unwrap();
-
-    assert_eq!(expected_string, actual_string);
+    assert_eq!(input, actual_string);
 }

--- a/parsers/rust/subtext/src/util.rs
+++ b/parsers/rust/subtext/src/util.rs
@@ -43,3 +43,20 @@ pub fn to_slug(input: &str) -> Result<String> {
 
     Ok(slug)
 }
+
+#[cfg(test)]
+pub fn assert_round_trip(input: &str) {
+    let blocks: Vec<crate::block::Block<crate::primitive::Entity>> =
+        crate::parse(input.as_bytes()).unwrap().collect();
+    let actual_bytes: Vec<u8> = blocks.iter().fold(Vec::new(), |mut bytes, block| {
+        bytes.append(&mut block.to_bytes());
+        bytes
+    });
+
+    let expected_bytes = Vec::from(input.as_bytes());
+
+    let actual_string = String::from_utf8(actual_bytes).unwrap();
+    let expected_string = String::from_utf8(expected_bytes).unwrap();
+
+    assert_eq!(expected_string, actual_string);
+}


### PR DESCRIPTION
In the course of resolving #45 and discussing #46, I uncovered that the Rust parser's representation of blocks is not well aligned with the spirit of the spec.

This change updates the block semantics of the Rust parser to align much more closely to the spec. Now, list blocks are broken out into individual items (previously sequential list items would accrue to a single block). Similarly, blanks are broken up by line (where previously they would accrue to a single block).

This revision gave rise to an opportunity to simplify parsing conditions significantly. Most notably: all sigil-specific code paths have been collapsed into one path.

In addition to the above changes, this change introduces two other meaningful updates:
 - We changed the representation of the underlying shared string to be thread-safe
 - A `to_text_content()` method was added for efficiently stringifying a block in a way that is aware of both sigils and leading whitespace

The revisions to the parser that were necessary to implement `to_text_content()` should set us up to easily revise things in the future if we decide that leading whitespace is significant for list blocks (per details in #31 and #46).

Fixes #45 