### PR TITLE
JavaScript parser

### DIFF
--- a/parsers/javascript/CharIterator.js
+++ b/parsers/javascript/CharIterator.js
@@ -22,8 +22,4 @@ export default class CharIterator {
   peek(numberOfChars) {
     return this.#chars.slice(this.#index + 1, this.#index + 1 + numberOfChars);
   }
-
-  peekBack() {
-    return this.#chars[this.#index - 1];
-  }
 }

--- a/parsers/javascript/CharIterator.js
+++ b/parsers/javascript/CharIterator.js
@@ -1,0 +1,29 @@
+export default class CharIterator {
+  #chars;
+  #index;
+
+  constructor(input) {
+    this.#chars = Array.from(input);
+    this.#index = -1;
+  }
+
+  next() {
+    this.#index++;
+    const done = this.#index === this.#chars.length;
+    return done ? {
+      done,
+      value: null,
+    } : {
+      done,
+      value: this.#chars[this.#index],
+    };
+  }
+
+  peek(numberOfChars) {
+    return this.#chars.slice(this.#index + 1, this.#index + 1 + numberOfChars);
+  }
+
+  peekBack() {
+    return this.#chars[this.#index - 1];
+  }
+}

--- a/parsers/javascript/README.md
+++ b/parsers/javascript/README.md
@@ -1,0 +1,25 @@
+# JavaScript Subtext Parser
+
+This is a JavaScript subtext parser with streaming capabaility.
+It uses the
+[Web Streams API](https://developer.mozilla.org/en-US/docs/Web/API/Streams_API),
+which means it can be used in compatible browsers and server runtimes like
+Node.js and Deno. It does not have any dependency.
+
+## Example
+
+Required runtime: Node.js >18.10.0
+
+This example must be run with Node.js as it uses the Node.js API to open
+the example source file. The main parser however is runtime-agnostic.
+
+`npm run example`
+
+## Run tests
+
+Required runtime: Node.js >18.10.0
+
+`npm run test`
+
+
+

--- a/parsers/javascript/examples/example.js
+++ b/parsers/javascript/examples/example.js
@@ -1,0 +1,32 @@
+/*
+  Notice:
+  This example must be run with Node.js as it uses the Node.js API to open
+  the example source file. The main parser however is runtime-agnostic.
+*/
+
+import fs from "node:fs";
+import * as path from "node:path";
+import * as url from "node:url";
+import { Readable } from 'node:stream';
+import subtextStreamingParser from "../index.js";
+
+const __dirname = path.dirname(url.fileURLToPath(import.meta.url));
+const nodeReadable = fs.createReadStream(
+  path.join(__dirname, "example.subtext"),
+  {
+    encoding: "utf-8",
+  }
+);
+const readableStream = Readable.toWeb(nodeReadable);
+const streamOfParsedData = readableStream.pipeThrough(
+  subtextStreamingParser(),
+);
+
+// Let's collect the incoming blocks from the stream
+const blocks = [];
+for await (const block of streamOfParsedData) {
+  blocks.push(block);
+}
+
+console.log("Parsed blocks:");
+console.log(JSON.stringify(blocks, null, "  "));

--- a/parsers/javascript/examples/example.subtext
+++ b/parsers/javascript/examples/example.subtext
@@ -1,0 +1,20 @@
+# First heading
+
+Some body text
+
+- List item one
+- List item two
+- List /with_link
+ - Not a list item
+
+> Block quote
+
+URLs like https://example.com are automatically linked.
+
+This text has an inline /slashlink.
+
+/stand-alone-slash-link
+
+# Second heading
+
+Closing text

--- a/parsers/javascript/index.js
+++ b/parsers/javascript/index.js
@@ -1,0 +1,34 @@
+import { parseLine } from "./utils.js";
+
+export const parseAtOnce = (input) => {
+  return input.split("\n").map(parseLine);
+}
+
+export default () => {
+  let buffer = "";
+
+  const parseLinesFromBuffer = (controller) => {
+    while (buffer.includes("\n")) {
+      const indexOfNewLine = buffer.indexOf("\n");
+      const line = buffer.substring(0, indexOfNewLine);
+      const parsedBlock = parseLine(line);
+      controller.enqueue(parsedBlock);
+      buffer = buffer.substring(indexOfNewLine + 1);
+    }
+  }
+
+  return new TransformStream({
+    transform(chunk, controller) {
+      buffer += chunk;
+      parseLinesFromBuffer(controller);
+    },
+    flush(controller) {
+      parseLinesFromBuffer(controller);
+      if (buffer.length > 0) {
+        const parsedBlock = parseLine(buffer);
+        controller.enqueue(parsedBlock);
+        buffer = "";
+      }
+    }
+  });
+}

--- a/parsers/javascript/package-lock.json
+++ b/parsers/javascript/package-lock.json
@@ -1,0 +1,12 @@
+{
+  "name": "subtext-parser",
+  "version": "0.1.0",
+  "lockfileVersion": 2,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "subtext-parser",
+      "version": "0.1.0"
+    }
+  }
+}

--- a/parsers/javascript/package.json
+++ b/parsers/javascript/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "subtext-parser",
+  "version": "0.1.0",
+  "type": "module",
+  "description": "A subtext parser written in JavaScript with streaming capability",
+  "main": "index.js",
+  "scripts": {
+    "example": "node examples/example.js",
+    "test": "node --test"
+  },
+  "author": ""
+}

--- a/parsers/javascript/test/blank.test.js
+++ b/parsers/javascript/test/blank.test.js
@@ -1,0 +1,164 @@
+import assert from 'node:assert';
+import { it } from 'node:test';
+import { parseAtOnce } from "../index.js";
+
+it("dissolves a terminating newline", () => {
+  const input = `Hello,
+World!`;
+
+  const actualOutput = parseAtOnce(input);
+  const expectedOutput = [
+    {
+      type: "paragraph",
+      content: [
+        {
+          type: "text-span",
+          content: "Hello,"
+        },
+      ],
+    },
+    {
+      type: "paragraph",
+      content: [
+        {
+          type: "text-span",
+          content: "World!"
+        },
+      ],
+    },
+  ];
+
+  assert.deepEqual(actualOutput, expectedOutput);
+});
+
+it("captures extra empty space in a blank", () => {
+  const input = `Hello,
+  
+World!`;
+
+  const actualOutput = parseAtOnce(input);
+  const expectedOutput = [
+    {
+      type: "paragraph",
+      content: [
+        {
+          type: "text-span",
+          content: "Hello,"
+        },
+      ],
+    },
+    {
+      type: "blank",
+      content: {
+        content: "  ",
+        type: "empty-space",
+      },
+    },
+    {
+      type: "paragraph",
+      content: [
+        {
+          type: "text-span",
+          content: "World!"
+        },
+      ],
+    },
+  ];
+
+  assert.deepEqual(actualOutput, expectedOutput);
+});
+
+it("recognizes zero length lines as blanks", () => {
+  const input = `Hello,
+  
+
+     
+World!`;
+
+  const actualOutput = parseAtOnce(input);
+  const expectedOutput = [
+    {
+      type: "paragraph",
+      content: [
+        {
+          type: "text-span",
+          content: "Hello,"
+        },
+      ],
+    },
+    {
+      type: "blank",
+      content: {
+        content: "  ",
+        type: "empty-space",
+      },
+    },
+    {
+      type: "blank",
+      content: {
+        content: "",
+        type: "empty-space",
+      },
+    },
+    {
+      type: "blank",
+      content: {
+        content: "     ",
+        type: "empty-space",
+      },
+    },
+    {
+      type: "paragraph",
+      content: [
+        {
+          type: "text-span",
+          content: "World!"
+        },
+      ],
+    },
+  ];
+
+  assert.deepEqual(actualOutput, expectedOutput);
+});
+
+
+it("does not absorb leading whitespace into a preceding blank", () => {
+  const input = `Hello,
+  
+ - World!`;
+
+  const actualOutput = parseAtOnce(input);
+  const expectedOutput = [
+    {
+      type: "paragraph",
+      content: [
+        {
+          type: "text-span",
+          content: "Hello,"
+        },
+      ],
+    },
+    {
+      type: "blank",
+      content: {
+        content: "  ",
+        type: "empty-space",
+      },
+    },
+    {
+      type: "paragraph",
+      content: [
+        {
+          type: "empty-space",
+          content: " "
+        },
+        {
+          type: "text-span",
+          content: "- World!"
+        },
+      ],
+    },
+  ];
+
+  assert.deepEqual(actualOutput, expectedOutput);
+});

--- a/parsers/javascript/test/block.test.js
+++ b/parsers/javascript/test/block.test.js
@@ -4,7 +4,7 @@ import { parseAtOnce } from "../index.js";
 import { blocksToString } from '../utils.js';
 
 const assertRoundTrip = (input) => {
-  const blocks = parseAtOnce(input); console.log(blocks)
+  const blocks = parseAtOnce(input);
   const stringFromBlocks = blocksToString(blocks);
   assert.strictEqual(input, stringFromBlocks);
 }

--- a/parsers/javascript/test/block.test.js
+++ b/parsers/javascript/test/block.test.js
@@ -1,0 +1,50 @@
+import assert from 'node:assert';
+import { it } from 'node:test';
+import { parseAtOnce } from "../index.js";
+import { blocksToString } from '../utils.js';
+
+const assertRoundTrip = (input) => {
+  const blocks = parseAtOnce(input); console.log(blocks)
+  const stringFromBlocks = blocksToString(blocks);
+  assert.strictEqual(input, stringFromBlocks);
+}
+
+it("coverts a list block to bytes", () => {
+  const input = `- List item one
+- List item two
+- List /with_link`;
+
+  assertRoundTrip(input);
+});
+
+it("coverts a paragraph block to bytes", () => {
+  const input = `URLs like https://example.com are automatically linked.`;
+
+  assertRoundTrip(input);
+});
+
+it("coverts a header block to bytes", () => {
+  const input = "# This is a header";
+
+  assertRoundTrip(input);
+});
+
+it("coverts a slashlink block to bytes", () => {
+  const input = "/foo/bar";
+
+  assertRoundTrip(input);
+});
+
+it("coverts a hyperlink block to bytes", () => {
+  const input = "https://foo.example.com?bar#baz";
+
+  assertRoundTrip(input);
+});
+
+it("coverts whitespace to bytes", () => {
+  const input = `
+       
+  `;
+
+  assertRoundTrip(input);
+});

--- a/parsers/javascript/test/parse.test.js
+++ b/parsers/javascript/test/parse.test.js
@@ -1,0 +1,511 @@
+import assert from 'node:assert';
+import { it } from 'node:test';
+import { parseAtOnce } from "../index.js";
+
+it("parses empty space", () => {
+  const input = `  
+
+          `;
+
+  const actualOutput = parseAtOnce(input);
+  const expectedOutput = [
+    {
+      type: "blank",
+      content: {
+        content: "  ",
+        type: "empty-space",
+      },
+    },
+    {
+      type: "blank",
+      content: {
+        content: "",
+        type: "empty-space",
+      },
+    },
+    {
+      type: "blank",
+      content: {
+        content: "          ",
+        type: "empty-space",
+      },
+    },
+  ];
+
+  assert.deepEqual(actualOutput, expectedOutput);
+});
+
+it("parses basic slash links", () => {
+  const input = `/foo/bar`;
+
+  const actualOutput = parseAtOnce(input);
+  const expectedOutput = [
+    {
+      type: "paragraph",
+      content: [
+        {
+          content: "/foo/bar",
+          type: "slashlink",
+        },
+      ],
+    },
+  ];
+
+  assert.deepEqual(actualOutput, expectedOutput);
+});
+
+it("parses basic headers", () => {
+  const input = `# Hello, world!`;
+
+  const actualOutput = parseAtOnce(input);
+  const expectedOutput = [
+    {
+      type: "header",
+      content: [
+        {
+          content: "#",
+          type: "sigil",
+        },
+        {
+          content: " ",
+          type: "empty-space"
+        },
+        {
+          content: "Hello, world!",
+          type: "text-span"
+        }
+      ],
+    },
+  ];
+
+  assert.deepEqual(actualOutput, expectedOutput);
+});
+
+it("parses basic paragraphs", () => {
+  const input = `This is a paragraph`;
+
+  const actualOutput = parseAtOnce(input);
+  const expectedOutput = [
+    {
+      type: "paragraph",
+      content: [
+        {
+          content: "This is a paragraph",
+          type: "text-span"
+        }
+      ],
+    },
+  ];
+
+  assert.deepEqual(actualOutput, expectedOutput);
+});
+
+it("parses basic hyperlinks", () => {
+  const input = `http://example.com/foo?bar=baz#zot`;
+
+  const actualOutput = parseAtOnce(input);
+  const expectedOutput = [
+    {
+      type: "paragraph",
+      content: [
+        {
+          content: "http://example.com/foo?bar=baz#zot",
+          type: "hyperlink"
+        }
+      ],
+    },
+  ];
+
+  assert.deepEqual(actualOutput, expectedOutput);
+});
+
+it("parses basic lists", () => {
+  const input = `- One
+- Two
+- Three`;
+
+  const actualOutput = parseAtOnce(input);
+  const expectedOutput = [
+    {
+      "type": "list",
+      "content": [
+        {
+          "type": "sigil",
+          "content": "-"
+        },
+        {
+          "type": "empty-space",
+          "content": " "
+        },
+        {
+          "type": "text-span",
+          "content": "One"
+        }
+      ]
+    },
+    {
+      "type": "list",
+      "content": [
+        {
+          "type": "sigil",
+          "content": "-"
+        },
+        {
+          "type": "empty-space",
+          "content": " "
+        },
+        {
+          "type": "text-span",
+          "content": "Two"
+        }
+      ]
+    },
+    {
+      "type": "list",
+      "content": [
+        {
+          "type": "sigil",
+          "content": "-"
+        },
+        {
+          "type": "empty-space",
+          "content": " "
+        },
+        {
+          "type": "text-span",
+          "content": "Three"
+        }
+      ]
+    },
+  ];
+
+  assert.deepEqual(actualOutput, expectedOutput);
+});
+
+it("headers with hyperlinks at the beginning", () => {
+  const input = `# http://example.com/foo?bar=baz#zot for example`;
+
+  const actualOutput = parseAtOnce(input);
+  const expectedOutput = [
+    {
+      "type": "header",
+      "content": [
+        {
+          "type": "sigil",
+          "content": "#"
+        },
+        {
+          "type": "empty-space",
+          "content": " "
+        },
+        {
+          "type": "hyperlink",
+          "content": "http://example.com/foo?bar=baz#zot"
+        },
+        {
+          "type": "text-span",
+          "content": " for example"
+        },
+      ]
+    },
+  ];
+
+  assert.deepEqual(actualOutput, expectedOutput);
+});
+
+it("headers with hyperlinks in the middle", () => {
+  const input = `# See http://example.com/foo?bar=baz#zot for example`;
+
+  const actualOutput = parseAtOnce(input);
+  const expectedOutput = [
+    {
+      "type": "header",
+      "content": [
+        {
+          "type": "sigil",
+          "content": "#"
+        },
+        {
+          "type": "empty-space",
+          "content": " "
+        },
+        {
+          "type": "text-span",
+          "content": "See "
+        },
+        {
+          "type": "hyperlink",
+          "content": "http://example.com/foo?bar=baz#zot"
+        },
+        {
+          "type": "text-span",
+          "content": " for example"
+        },
+      ]
+    },
+  ];
+
+  assert.deepEqual(actualOutput, expectedOutput);
+});
+
+it("headers with hyperlinks at the end", () => {
+  const input = `# Example link: http://example.com/foo?bar=baz#zot`;
+
+  const actualOutput = parseAtOnce(input);
+  const expectedOutput = [
+    {
+      "type": "header",
+      "content": [
+        {
+          "type": "sigil",
+          "content": "#"
+        },
+        {
+          "type": "empty-space",
+          "content": " "
+        },
+        {
+          "type": "text-span",
+          "content": "Example link: "
+        },
+        {
+          "type": "hyperlink",
+          "content": "http://example.com/foo?bar=baz#zot"
+        },
+      ]
+    },
+  ];
+
+  assert.deepEqual(actualOutput, expectedOutput);
+});
+
+
+it("list: one item is a sublink", () => {
+  const input = `- One
+- /two
+- Three`;
+
+  const actualOutput = parseAtOnce(input);
+  const expectedOutput = [
+    {
+      "type": "list",
+      "content": [
+        {
+          "type": "sigil",
+          "content": "-"
+        },
+        {
+          "type": "empty-space",
+          "content": " "
+        },
+        {
+          "type": "text-span",
+          "content": "One"
+        },
+      ],
+    },
+    {
+      "type": "list",
+      "content": [
+        {
+          "type": "sigil",
+          "content": "-"
+        },
+        {
+          "type": "empty-space",
+          "content": " "
+        },
+        {
+          "type": "slashlink",
+          "content": "/two"
+        },
+      ],
+    },
+    {
+      "type": "list",
+      "content": [
+        {
+          "type": "sigil",
+          "content": "-"
+        },
+        {
+          "type": "empty-space",
+          "content": " "
+        },
+        {
+          "type": "text-span",
+          "content": "Three"
+        },
+      ],
+    },
+  ];
+
+  assert.deepEqual(actualOutput, expectedOutput);
+});
+
+
+it("paragraph with slashlink at the beginning", () => {
+  const input = `/foo/bar for example`;
+
+  const actualOutput = parseAtOnce(input);
+  const expectedOutput = [
+    {
+      type: "paragraph",
+      content: [
+        {
+          content: "/foo/bar",
+          type: "slashlink"
+        },
+        {
+          content: " for example",
+          type: "text-span"
+        }
+      ],
+    },
+  ];
+
+  assert.deepEqual(actualOutput, expectedOutput);
+});
+
+
+it("paragraph with slashlink in the middle", () => {
+  const input = `See /foo/bar for example`;
+
+  const actualOutput = parseAtOnce(input);
+  const expectedOutput = [
+    {
+      type: "paragraph",
+      content: [
+        {
+          content: "See ",
+          type: "text-span"
+        },
+        {
+          content: "/foo/bar",
+          type: "slashlink"
+        },
+        {
+          content: " for example",
+          type: "text-span"
+        }
+      ],
+    },
+  ];
+
+  assert.deepEqual(actualOutput, expectedOutput);
+});
+
+
+it("paragraph with slashlink at the end", () => {
+  const input = `Example link: /foo/bar`;
+
+  const actualOutput = parseAtOnce(input);
+  const expectedOutput = [
+    {
+      type: "paragraph",
+      content: [
+        {
+          content: "Example link: ",
+          type: "text-span"
+        },
+        {
+          content: "/foo/bar",
+          type: "slashlink"
+        },
+      ],
+    },
+  ];
+
+  assert.deepEqual(actualOutput, expectedOutput);
+});
+
+
+it("paragraph with hyperlink at the beginning", () => {
+  const input = `http://example.com/foo?bar=baz#zot for example`;
+
+  const actualOutput = parseAtOnce(input);
+  const expectedOutput = [
+    {
+      type: "paragraph",
+      content: [
+        {
+          content: "http://example.com/foo?bar=baz#zot",
+          type: "hyperlink"
+        },
+        {
+          content: " for example",
+          type: "text-span"
+        },
+      ],
+    },
+  ];
+
+  assert.deepEqual(actualOutput, expectedOutput);
+});
+
+it("paragraph with hyperlink in the middle", () => {
+  const input = `See http://example.com/foo?bar=baz#zot for example`;
+
+  const actualOutput = parseAtOnce(input);
+  const expectedOutput = [
+    {
+      type: "paragraph",
+      content: [
+        {
+          content: "See ",
+          type: "text-span"
+        },
+        {
+          content: "http://example.com/foo?bar=baz#zot",
+          type: "hyperlink"
+        },
+        {
+          content: " for example",
+          type: "text-span"
+        },
+      ],
+    },
+  ];
+
+  assert.deepEqual(actualOutput, expectedOutput);
+});
+
+it("paragraph with hyperlink at the end", () => {
+  const input = `Example link: http://example.com/foo?bar=baz#zot`;
+
+  const actualOutput = parseAtOnce(input);
+  const expectedOutput = [
+    {
+      type: "paragraph",
+      content: [
+        {
+          content: "Example link: ",
+          type: "text-span"
+        },
+        {
+          content: "http://example.com/foo?bar=baz#zot",
+          type: "hyperlink"
+        },
+      ],
+    },
+  ];
+
+  assert.deepEqual(actualOutput, expectedOutput);
+});
+
+it("parses complex multiline subtext", () => {
+  const input = `# Html
+
+It is a /markup language.
+Based around the concept of [[Blocks]].
+
+http://www.google.com
+
+ - One
+ - /two
+ - I bet [[you thought]] I would write three`;
+
+  const blocks = parseAtOnce(input);
+
+  assert.strictEqual(blocks.length, 10);
+});

--- a/parsers/javascript/test/text-content.test.js
+++ b/parsers/javascript/test/text-content.test.js
@@ -1,0 +1,128 @@
+import assert from 'node:assert';
+import { it } from 'node:test';
+import { parseAtOnce } from "../index.js";
+
+it("skips leading whitespace in paragraphs", () => {
+  const input = `  Hello, world!`;
+
+  const actualOutput = parseAtOnce(input);
+  const expectedOutput = [
+    {
+      type: "paragraph",
+      content: [
+        {
+          content: "  ",
+          type: "empty-space"
+        },
+        {
+          content: "Hello, world!",
+          type: "text-span"
+        },
+      ],
+    },
+  ];
+
+  assert.deepEqual(actualOutput, expectedOutput);
+});
+
+
+it("skips and leading whitespace for headers", () => {
+  const input = `# Hello, world!`;
+
+  const actualOutput = parseAtOnce(input);
+  const expectedOutput = [
+    {
+      type: "header",
+      content: [
+        {
+          content: "#",
+          type: "sigil"
+        },
+        {
+          content: " ",
+          type: "empty-space"
+        },
+        {
+          content: "Hello, world!",
+          type: "text-span"
+        },
+      ],
+    },
+  ];
+
+  assert.deepEqual(actualOutput, expectedOutput);
+});
+
+
+it("skips and leading whitespace for lists", () => {
+  const input = `- Hello, world!`;
+
+  const actualOutput = parseAtOnce(input);
+  const expectedOutput = [
+    {
+      type: "list",
+      content: [
+        {
+          content: "-",
+          type: "sigil"
+        },
+        {
+          content: " ",
+          type: "empty-space"
+        },
+        {
+          content: "Hello, world!",
+          type: "text-span"
+        },
+      ],
+    },
+  ];
+
+  assert.deepEqual(actualOutput, expectedOutput);
+});
+
+
+it("skips and leading whitespace for quotes", () => {
+  const input = `> Hello, world!`;
+
+  const actualOutput = parseAtOnce(input);
+  const expectedOutput = [
+    {
+      type: "quote",
+      content: [
+        {
+          content: ">",
+          type: "sigil"
+        },
+        {
+          content: " ",
+          type: "empty-space"
+        },
+        {
+          content: "Hello, world!",
+          type: "text-span"
+        },
+      ],
+    },
+  ];
+
+  assert.deepEqual(actualOutput, expectedOutput);
+});
+
+
+it("yields an empty string for blanks", () => {
+  const input = `   `;
+
+  const actualOutput = parseAtOnce(input);
+  const expectedOutput = [
+    {
+      type: "blank",
+      content: {
+        content: "   ",
+        type: "empty-space"
+      },
+    },
+  ];
+
+  assert.deepEqual(actualOutput, expectedOutput);
+});

--- a/parsers/javascript/utils.js
+++ b/parsers/javascript/utils.js
@@ -1,0 +1,187 @@
+import CharIterator from "./CharIterator.js";
+
+const BlockType = {
+  HEADER: "header",
+  BLANK: "blank",
+  PARAGRAPH: "paragraph",
+  LIST: "list",
+  LINK: "link",
+  QUOTE: "quote",
+}
+
+
+const TokenType = {
+  SIGIL: "sigil",
+  EMPTY_SPACE: "empty-space",
+  TEXT_SPAN: "text-span",
+  HYPERLINK: "hyperlink",
+  SLASHLINK: "slashlink",
+}
+
+
+const isWhiteSpace = (string) => {
+  return string.trim().length === 0;
+};
+
+
+const parseText = (text) => {
+  const spans = [];
+  const iterator = new CharIterator(text);
+  let currentSpanType;
+  let currentSpanText = "";
+
+  while (true) {
+    const step = iterator.next();
+    if (step.done) {
+      spans.push({
+        type: currentSpanType,
+        content: currentSpanText,
+      });
+      break;
+    }
+    const char = step.value;
+    const lastChar = iterator.peekBack();
+
+    if (typeof lastChar !== "string" || isWhiteSpace(lastChar)) {
+      if (
+        char === "h"
+        && (
+          iterator.peek(5).join("") === "ttp:/"
+          || iterator.peek(6).join("") === "ttps:/"
+        )
+      ) {
+        currentSpanType && spans.push({
+          type: currentSpanType,
+          content: currentSpanText,
+        });
+  
+        currentSpanText = "";
+        currentSpanType = TokenType.HYPERLINK;
+      } else if (
+        char === "/"
+      ) {
+        currentSpanType && spans.push({
+          type: currentSpanType,
+          content: currentSpanText,
+        });
+  
+        currentSpanText = "";
+        currentSpanType = TokenType.SLASHLINK;
+      } else {
+        currentSpanType = TokenType.TEXT_SPAN;
+      }
+    }
+
+    if (
+      isWhiteSpace(char) && currentSpanType !== TokenType.TEXT_SPAN
+    ) {
+      currentSpanType && spans.push({
+        type: currentSpanType,
+        content: currentSpanText,
+      });
+      currentSpanText = "";
+      currentSpanType = TokenType.TEXT_SPAN;
+    }
+
+    currentSpanText += char;
+  }
+
+  return spans;
+};
+
+
+export const toString = (object) => { console.log(object)
+  if (typeof object.content === "string") {
+    return object.content;
+  }
+  if (Array.isArray(object)) {
+    return object.reduce((a, b) => a + toString(b), "");
+  }
+  return toString(object.content);
+}
+
+
+export const blocksToString = (blocks) => {
+  return blocks.map(toString).join("\n");
+}
+
+
+const parseExtraSpace = (line, content) => {
+  return line.substring(0, line.indexOf(toString(content)));
+}
+
+
+const parseSigilPrefixedLine = (line, blockType) => {
+  const block = {
+    type: blockType,
+    content: [
+      {
+        type: TokenType.SIGIL,
+        content: line.substring(0, 1),
+      },
+    ]
+  };
+
+  const content = parseText(line.substring(1).trimStart());
+  const emptySpace = parseExtraSpace(line.substring(1), content);
+
+  if (emptySpace.length > 0) {
+    block.content.push({
+      type: TokenType.EMPTY_SPACE,
+      content: emptySpace,
+    })
+  }
+
+  if (toString(content).length > 0) {
+    block.content.push(...content);
+  }
+
+  return block;
+}
+
+
+const parseBlockWithoutSigil = (line) => {
+  if (line.trim().length === 0) {
+    return {
+      type: BlockType.BLANK,
+      content: {
+        type: TokenType.EMPTY_SPACE,
+        content: line,
+      },
+    };
+  } else {
+    const block = {
+      type: BlockType.PARAGRAPH,
+      content: [],
+    };
+  
+    const content = parseText(line.trimStart());
+    const emptySpace = parseExtraSpace(line, content);
+  
+    if (emptySpace.length > 0) {
+      block.content.push({
+        type: TokenType.EMPTY_SPACE,
+        content: emptySpace,
+      })
+    }
+  
+    if (toString(content).length > 0) {
+      block.content.push(...content);
+    }
+
+    return block;
+  }
+}
+
+
+export const parseLine = (line) => {
+  if (line.startsWith("#")) {
+    return parseSigilPrefixedLine(line, BlockType.HEADER);
+  } else if (line.startsWith("-")) {
+    return parseSigilPrefixedLine(line, BlockType.LIST);
+  } else if (line.startsWith(">")) {
+    return parseSigilPrefixedLine(line, BlockType.QUOTE);
+  } else {
+    return parseBlockWithoutSigil(line);
+  }
+};

--- a/parsers/javascript/utils.js
+++ b/parsers/javascript/utils.js
@@ -27,6 +27,8 @@ const isWhiteSpace = (string) => {
 const parseText = (text) => {
   const spans = [];
   const iterator = new CharIterator(text);
+  let char;
+  let previousChar;
   let currentSpanType;
   let currentSpanText = "";
 
@@ -39,10 +41,10 @@ const parseText = (text) => {
       });
       break;
     }
-    const char = step.value;
-    const lastChar = iterator.peekBack();
+    previousChar = char;
+    char = step.value;
 
-    if (typeof lastChar !== "string" || isWhiteSpace(lastChar)) {
+    if (typeof previousChar !== "string" || isWhiteSpace(previousChar)) {
       if (
         char === "h"
         && (

--- a/parsers/javascript/utils.js
+++ b/parsers/javascript/utils.js
@@ -90,7 +90,7 @@ const parseText = (text) => {
 };
 
 
-export const toString = (object) => { console.log(object)
+export const toString = (object) => {
   if (typeof object.content === "string") {
     return object.content;
   }


### PR DESCRIPTION
This is a JavaScript parser for Subtext with streaming capability. Since I am using something similar for my own notes app, I thought I might as well provide a parser for this repo.

It uses the [Web Streams API](https://developer.mozilla.org/en-US/docs/Web/API/Streams_API) which means it can be used with compatible browsers and server runtimes like [Node.js](https://nodejs.org/api/webstreams.html) and Deno. The parser does not have any dependency.

I have included the example from the Rust parser and some tests from the Rust test suite.

You can run the example via `npm run example` and run tests via `npm run test`.

Feel free to suggest improvements or close the request if it does not match your requirements. If you prefer TypeScript, I could also make the adjustments.